### PR TITLE
Changed Debian version in images to fix an error when opening in devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
 {
 	"name": "Python 3",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/python:2-3.12-bullseye",
+	"image": "mcr.microsoft.com/devcontainers/python:3.12-bookworm",
 	"features": {
 		"ghcr.io/devcontainers-extra/features/uv:1": {},
 		"ghcr.io/devcontainers/features/docker-in-docker:2": {}


### PR DESCRIPTION
Previously, reopening the repository in a devcontainer yielded this error message:

`ERROR: failed to build: failed to solve: process "/bin/sh -c cp -ar /tmp/build-features-src/uv_0 /tmp/dev-container-features && chmod -R 0755 /tmp/dev-container-features/uv_0 && cd /tmp/dev-container-features/uv_0 && chmod +x ./devcontainer-features-install.sh && ./devcontainer-features-install.sh && rm -rf /tmp/dev-container-features/uv_0" did not complete successfully: exit code: 1 exit status 1`

Similarly, there was also an issue with reopening it on Codespaces.

Changing the image linked in the devcontainer file seemed to have fixed the issue.